### PR TITLE
Use new flag.FlagSet methods

### DIFF
--- a/flagg.go
+++ b/flagg.go
@@ -16,15 +16,15 @@ func New(name, usage string) *flag.FlagSet {
 	return f
 }
 
-// SimpleUsage returns a func that writes usage to os.Stderr. If cmd has
+// SimpleUsage returns a func that writes usage to cmd.Output(). If cmd has
 // associated flags, the func also calls cmd.PrintDefaults.
 func SimpleUsage(cmd *flag.FlagSet, usage string) func() {
 	return func() {
-		os.Stderr.WriteString(usage)
+		cmd.Output().Write([]byte(usage))
 		numFlags := 0
 		cmd.VisitAll(func(*flag.Flag) { numFlags++ })
 		if numFlags > 0 {
-			os.Stderr.WriteString("\nFlags:\n")
+			cmd.Output().Write([]byte("\nFlags:\n"))
 			cmd.PrintDefaults()
 		}
 	}

--- a/flagg.go
+++ b/flagg.go
@@ -3,7 +3,6 @@ package flagg
 import (
 	"flag"
 	"os"
-	"unsafe"
 )
 
 // Root is the default root flag.FlagSet.
@@ -48,22 +47,10 @@ func parse(tree Tree, args []string) *flag.FlagSet {
 	args = tree.Cmd.Args()
 	if len(args) > 0 {
 		for _, t := range tree.Sub {
-			if name(t.Cmd) == args[0] {
+			if t.Cmd.Name() == args[0] {
 				return parse(t, args[1:])
 			}
 		}
 	}
 	return tree.Cmd
-}
-
-// unfortunately the flag API doesn't provide a way to access the name of a
-// FlagSet after it's created, so we have to resort to this hack for now.
-func name(f *flag.FlagSet) string {
-	// from src/flag/flag.go
-	// This should be relatively safe, since the first two fields of
-	// flag.FlagSet haven't changed in 6 years (!!)
-	return (*struct {
-		usage func()
-		name  string
-	})(unsafe.Pointer(f)).name
 }

--- a/flagg_test.go
+++ b/flagg_test.go
@@ -1,7 +1,7 @@
 package flagg
 
 import (
-	"io/ioutil"
+	"bytes"
 	"os"
 	"testing"
 )
@@ -28,41 +28,23 @@ func TestParse(t *testing.T) {
 func TestSimpleUsage(t *testing.T) {
 	foo := New("foo", "")
 	usage := "foo bar baz"
+	buf := new(bytes.Buffer)
+	foo.SetOutput(buf)
 
 	// no flags
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	os.Stderr = f
 	SimpleUsage(foo, usage)()
-	b, err := ioutil.ReadFile(f.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != usage {
-		t.Fatalf("expected %q, got %q", usage, string(b))
+	if out := string(buf.Next(len(usage))); out != usage {
+		t.Fatalf("expected %q, got %q", usage, out)
 	}
 
 	// with flag
-	f, err = ioutil.TempFile("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	os.Stderr = f
 	foo.Bool("v", false, "")
 	SimpleUsage(foo, usage)()
-	b, err = ioutil.ReadFile(f.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
 	exp := usage + `
 Flags:
   -v	
 `
-	if string(b) != exp {
-		t.Fatalf("expected %q, got %q", exp, string(b))
+	if out := string(buf.Next(len(usage))); out != usage {
+		t.Fatalf("expected %q, got %q", usage, out)
 	}
 }


### PR DESCRIPTION
Once Go 1.10 is released (on track for Feb 2018), we can use these methods instead of the `unsafe` hack. Until then, I can't recommend that anyone use this package.

See https://tip.golang.org/doc/go1.10#minor_library_changes